### PR TITLE
Generate companies customed url

### DIFF
--- a/api/v1/company/models.py
+++ b/api/v1/company/models.py
@@ -1,3 +1,7 @@
 from django.db import models
+from common.models import User
 
-# Create your models here.
+
+class RealEstateCompany(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="company")
+    custom_url = models.CharField(max_length=255, blank=True, null=True)

--- a/api/v1/company/serializers.py
+++ b/api/v1/company/serializers.py
@@ -1,0 +1,22 @@
+from common.models import User
+from rest_framework import serializers
+from company.models import RealEstateCompany
+from django.utils.text import slugify
+
+
+class RealEstateSerialize(serializers.ModelSerializer):
+    class Meta:
+        model = RealEstateCompany
+        fields = ["user", "custom_url"]
+
+        def create(self, validated_data):
+            user = validated_data.pop("user")
+            base_slug = slugify(user.business_name)
+            custom_url = f"{base_slug}.propertyhive.com"
+            if RealEstateCompany.objects.filter(custom_url=custom_url).exists():
+                raise serializers.ValidationError(
+                    {"message": "This url is already taken"}
+                )
+            validated_data["custom_url"] = custom_url
+            company = RealEstateCompany.objects.create(user=user, **validated_data)
+            return company

--- a/api/v1/company/urls.py
+++ b/api/v1/company/urls.py
@@ -1,4 +1,10 @@
-from django.urls import path, include
-from . import views
+from django.urls import path
+from .views import generate_custom_url
 
-urlpatterns = []
+urlpatterns = [
+    path(
+        "companies/generate-url/",
+        generate_custom_url,
+        name="generate_custom_url",
+    ),
+]

--- a/api/v1/company/urls.py
+++ b/api/v1/company/urls.py
@@ -1,10 +1,9 @@
 from django.urls import path
-from .views import generate_custom_url
+from .views import RealEstateCompanyViewSet
+from rest_framework.routers import DefaultRouter
 
-urlpatterns = [
-    path(
-        "companies/generate-url/",
-        generate_custom_url,
-        name="generate_custom_url",
-    ),
-]
+urlpatterns = []
+
+router = DefaultRouter()
+
+router.register(r"generate-url", RealEstateCompanyViewSet, basename="company")

--- a/api/v1/company/views.py
+++ b/api/v1/company/views.py
@@ -1,24 +1,13 @@
 from django.http import JsonResponse
 from django.utils.text import slugify
 from django.shortcuts import get_object_or_404
-from .models import Company
-from rest_framework.decorators import api_view
+from .models import RealEstateCompany
+from rest_framework import viewsets
 
 
-@api_view(["POST"])
-def generate_custom_url(request):
-    company_id = request.data.get("company_id")
-    company = get_object_or_404(Company, id=company_id)
+class RealEstateCompanyViewSet(viewsets.ViewSet):
+    serializer_class = RealEstateCompany
+    queryset = RealEstateCompany.objects.all()
 
-    if not company.custom_url:
-        slug = slugify(company.name)
-        company.custom_url = f"{slug}.propertyhive.com"
-        company.save()
-
-    return JsonResponse(
-        {
-            "status_code": 200,
-            "message": "Custom URL generated successfully",
-            "data": {"custom_url": company.custom_url},
-        }
-    )
+    def create(self, serializer):
+        serializer.save()

--- a/api/v1/company/views.py
+++ b/api/v1/company/views.py
@@ -1,3 +1,24 @@
-from django.shortcuts import render
+from django.http import JsonResponse
+from django.utils.text import slugify
+from django.shortcuts import get_object_or_404
+from .models import Company
+from rest_framework.decorators import api_view
 
-# Create your views here.
+
+@api_view(["POST"])
+def generate_custom_url(request):
+    company_id = request.data.get("company_id")
+    company = get_object_or_404(Company, id=company_id)
+
+    if not company.custom_url:
+        slug = slugify(company.name)
+        company.custom_url = f"{slug}.propertyhive.com"
+        company.save()
+
+    return JsonResponse(
+        {
+            "statusCode": 200,
+            "message": "Custom URL generated successfully",
+            "data": {"customUrl": company.custom_url},
+        }
+    )

--- a/api/v1/company/views.py
+++ b/api/v1/company/views.py
@@ -17,8 +17,8 @@ def generate_custom_url(request):
 
     return JsonResponse(
         {
-            "statusCode": 200,
+            "status_code": 200,
             "message": "Custom URL generated successfully",
-            "data": {"customUrl": company.custom_url},
+            "data": {"custom_url": company.custom_url},
         }
     )

--- a/property_hive/settings.py
+++ b/property_hive/settings.py
@@ -15,6 +15,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+APPEND_SLASH = False
 
 # Application definition
 


### PR DESCRIPTION
Generate Custom URLs for Companies.
​
## Description
This endpoint will close #3 issue that demands creating a generated company's URL endpoint.
The endpoint "API/v1/generate-URL/, will generate a custom url for the company.
​
## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation as needed.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.